### PR TITLE
feat: 添加 Docker 一键部署支持

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# ElainaBot Docker 部署 - 忽略不需要打包进镜像的文件
+
+# Python 缓存
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# 虚拟环境
+venv/
+.venv/
+env/
+
+# 日志（运行时产生，挂载卷解决）
+log/
+
+# 本地 IDE 配置
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Git
+.git/
+.gitignore
+
+# Docker 自身
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# 数据库文件（运行时产生）
+*.db
+*.sqlite
+*.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# ElainaBot v2 - Docker 镜像
+FROM python:3.11-slim
+
+# 设置工作目录
+WORKDIR /app
+
+# 设置 pip 镜像源（加速国内下载）
+RUN pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+
+# 先复制依赖文件，利用 Docker 缓存层
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 复制源码
+COPY . .
+
+# 暴露 Web 面板端口（与 settings.yaml 中 server.port 一致）
+EXPOSE 5200
+
+# 启动
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -148,6 +148,65 @@ def _on_load():
 
 **插件开发者** 请前往 [Elaina-plugins](https://github.com/ElainaCore/Elaina-plugins) 提交 PR，将你的插件加入市场。
 
+## 🐳 Docker 一键部署
+
+### 环境要求
+
+- [Docker](https://docs.docker.com/get-docker/) 20.10+
+- [Docker Compose](https://docs.docker.com/compose/install/) v2+
+
+### 快速启动
+
+**1. 克隆仓库**
+
+```bash
+git clone https://github.com/ElainaCore/ElainaBot_v2.git
+cd ElainaBot_v2
+```
+
+**2. 构建并启动**
+
+```bash
+docker compose up -d --build
+```
+
+**3. 访问 Web 面板完成配置**
+
+```
+http://localhost:5200/web/?token=admin
+```
+
+在面板中填写机器人的 `APPID` 和 `Secret` 后即可正常运行。
+
+### 常用命令
+
+```bash
+# 查看实时日志
+docker compose logs -f
+
+# 停止
+docker compose down
+
+# 重启
+docker compose restart
+
+# 更新代码后重新构建
+docker compose up -d --build
+```
+
+### 数据持久化说明
+
+以下目录已通过 Volume 挂载到宿主机，容器删除后数据不会丢失：
+
+| 目录 | 说明 |
+|------|------|
+| `./config/` | 机器人配置文件 |
+| `./plugins/` | 已安装的插件 |
+| `./modules/` | 模块文件 |
+| `./log/` | 运行日志 |
+
+---
+
 ## 📄 License
 
 MIT License

--- a/core/bot.py
+++ b/core/bot.py
@@ -191,13 +191,13 @@ class BotManager:
 
         # 3. 校验机器人配置
         bot_configs = cfg.get_bot_configs()
+        valid_bots = []
+        if bot_configs:
+            valid_bots = [b for b in bot_configs if b.get('appid') and b.get('secret')]
         if not bot_configs:
-            log.error("未配置任何机器人, 请编辑 config/bot.yaml")
-            return
-        valid_bots = [b for b in bot_configs if b.get('appid') and b.get('secret')]
-        if not valid_bots:
-            log.error("所有机器人配置均缺少 appid 或 secret")
-            return
+            log.warning("未配置任何机器人, 请通过 Web 面板填写配置")
+        elif not valid_bots:
+            log.warning("所有机器人配置均缺少 appid 或 secret, 请通过 Web 面板填写配置")
 
         # 4. 初始化模块管理器
         modules_dir = os.path.join(self._base_dir, 'modules')
@@ -232,8 +232,7 @@ class BotManager:
         cfg.on_change('bot', self._on_bot_config_change)
 
         if not self._bots:
-            log.error("没有成功启动的机器人")
-            return
+            log.warning("没有成功启动的机器人, 请通过 Web 面板填写机器人配置")
 
         # 8. 启动 DAU 统计服务
         self._dau_service = DAUService(log_base)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  elainabot:
+    build: .
+    container_name: elainabot_v2
+    restart: unless-stopped
+    ports:
+      - "5200:5200"       # Web 管理面板
+    volumes:
+      # 持久化配置、插件、模块、日志数据
+      - ./config:/app/config
+      - ./plugins:/app/plugins
+      - ./modules:/app/modules
+      - ./log:/app/log
+    environment:
+      # 时区设置（可改成你当地时区）
+      - TZ=Asia/Shanghai
+    tty: true
+    stdin_open: true

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+echo ">>> 克隆 ElainaBot v2 仓库..."
+git clone https://github.com/ElainaCore/ElainaBot_v2.git
+cd ElainaBot_v2
+
+echo ">>> 构建并启动 Docker 容器..."
+docker compose up -d --build
+
+echo ""
+echo ">>> 部署完成！"
+echo ">>> 访问面板: http://localhost:5200/web/?token=admin"
+echo ">>> 查看日志: docker compose logs -f"
+echo ">>> 停止服务: docker compose down"


### PR DESCRIPTION
## 改动内容

- 新增 `Dockerfile`（基于 python:3.11-slim，已配置清华 pip 镜像加速）
- 新增 `docker-compose.yml`（挂载 config/plugins/modules/log 目录持久化数据）
- 新增 `.dockerignore`（排除缓存/日志/虚拟环境，减小镜像体积）
- 新增 `install.sh`（一键部署脚本）
- 修复 `core/bot.py`：允许无配置启动，Web 面板可正常访问进行配置
- 更新 `README.md`，新增 Docker 部署章节

## 使用方式

```bash
docker compose up -d --build