### PR TITLE
feat: Docker 一键部署 + 首次启动自动配置

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,16 @@ RUN pip install --no-cache-dir -r requirements.txt
 # 复制源码
 COPY . .
 
+# 备份默认配置、插件、模块（用于首次启动时复制到挂载卷）
+RUN cp -r /app/config /app/config.defaults && \
+    cp -r /app/plugins /app/plugins.defaults && \
+    cp -r /app/modules /app/modules.defaults
+
+# 给 entrypoint 脚本执行权限
+RUN chmod +x /app/docker-entrypoint.sh
+
 # 暴露 Web 面板端口（与 settings.yaml 中 server.port 一致）
 EXPOSE 5200
 
-# 启动
-CMD ["python", "main.py"]
+# 入口脚本：首次启动自动复制默认配置
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# 如果挂载的 config 目录为空，复制默认配置
+if [ ! -f /app/config/settings.yaml ]; then
+    echo ">>> 首次启动，复制默认配置..."
+    mkdir -p /app/config
+    cp /app/config.defaults/settings.yaml /app/config/settings.yaml
+    cp /app/config.defaults/bot.yaml /app/config/bot.yaml 2>/dev/null || true
+fi
+
+# 如果挂载的 plugins 目录为空，复制系统插件
+if [ ! -d /app/plugins/system ]; then
+    echo ">>> 首次启动，复制默认插件..."
+    mkdir -p /app/plugins
+    cp -r /app/plugins.defaults/* /app/plugins/ 2>/dev/null || true
+fi
+
+# 如果挂载的 modules 目录为空，复制默认模块
+if [ ! -d /app/modules ]; then
+    echo ">>> 首次启动，复制默认模块..."
+    mkdir -p /app/modules
+    cp -r /app/modules.defaults/* /app/modules/ 2>/dev/null || true
+fi
+
+echo ">>> 启动 ElainaBot..."
+exec python main.py "$@"


### PR DESCRIPTION
## 改动

- Dockerfile: 首次启动自动复制默认配置
- docker-compose.yml: 持久化数据目录
- docker-entrypoint.sh: entrypoint 脚本
- .dockerignore: 减小镜像体积
- .github: Actions 自动构建推送
- README: 新增 Docker 部署文档
- core/bot.py: 允许无配置启动

## 部署

```bash
docker run -d --name elainabot -p 5200:5200 elainabot/elainabot:latest
```