### PR TITLE
refactor(plugins): 插件禁用机制从 .ban 文件迁移到 JSON 持久化

### DIFF
--- a/core/plugin/_loader.py
+++ b/core/plugin/_loader.py
@@ -76,9 +76,13 @@ class _LoaderMixin:
             log.warning(f'插件目录为空: {self._dir}')
             return
         dirs = sorted(d for d in os.listdir(self._dir) if os.path.isdir(os.path.join(self._dir, d)) and not d.startswith(('_', '.')))
-        loaded = large = 0
+        loaded = skipped = large = 0
         for name in dirs:
             try:
+                if name in self._disabled_plugins:
+                    log.info(f'插件 [{name}] 已禁用, 跳过加载')
+                    skipped += 1
+                    continue
                 if self._find_large_entry(os.path.join(self._dir, name)):
                     await self._load_large(name)
                     large += 1
@@ -91,15 +95,17 @@ class _LoaderMixin:
                 report_error(PLUGIN, name, e)
         self._rebuild_handler_list()
         self._snapshot_all_mtimes()
-        log.info(f'插件加载完成: {loaded}/{len(dirs)} 个 (大型 {large}), 共 {self.handler_count} 个处理器')
+        log.info(f'插件加载完成: {loaded}/{len(dirs)} 个 (大型 {large}, 跳过 {skipped}), 共 {self.handler_count} 个处理器')
 
     async def load(self, name):
         plugin_dir = os.path.join(self._dir, name)
         if not os.path.isdir(plugin_dir):
-            raise FileNotFoundError(f'插件目录不存在: {plugin_dir}')
+            get_logger(PLUGIN, name).error(f'[{name}]插件所在目录不存在: {plugin_dir}')
+            return
         py_files = self._list_py_files(plugin_dir)
         if not py_files:
-            raise FileNotFoundError(f'插件目录中无 .py 文件: {plugin_dir}')
+            get_logger(PLUGIN, name).error(f'[{name}]插件所在目录中无 .py 文件: {plugin_dir}')
+            return
         async with self._lock:
             if name in self._plugins:
                 await self._unload_plugin(name)
@@ -150,7 +156,8 @@ class _LoaderMixin:
         plugin_dir = os.path.join(self._dir, name)
         entry = self._find_large_entry(plugin_dir)
         if not entry:
-            raise FileNotFoundError(f'大型插件入口不存在: {plugin_dir}')
+            get_logger(PLUGIN, name).error(f'[{name}]为大型插件（文件夹型插件），但入口不存在: {plugin_dir}')
+            return
         async with self._lock:
             if name in self._plugins:
                 await self._unload_plugin(name)

--- a/core/plugin/manager.py
+++ b/core/plugin/manager.py
@@ -1,6 +1,7 @@
 """插件管理器 — 加载/卸载/分发/热重载"""
 
 import asyncio
+import json
 import os
 from collections import OrderedDict
 
@@ -27,6 +28,7 @@ class PluginManager(_LoaderMixin, _WatcherMixin, _DispatchMixin, _BlacklistMixin
         self._blacklist_users = set()
         self._blacklist_groups = set()
         self._plugin_bots = {}
+        self._disabled_plugins = set()
         self._lock = asyncio.Lock()
         self._base_dir = os.path.dirname(self._dir)
         self._file_mtimes = {}
@@ -34,6 +36,8 @@ class PluginManager(_LoaderMixin, _WatcherMixin, _DispatchMixin, _BlacklistMixin
         self._watcher_running = False
         self._load_blacklists()
         self._load_plugin_bots()
+        self._load_disabled_plugins()
+        self._migrate_ban_files()
 
     @property
     def plugins(self):
@@ -69,24 +73,43 @@ class PluginManager(_LoaderMixin, _WatcherMixin, _DispatchMixin, _BlacklistMixin
     # ==================== 管理接口 ====================
 
     def enable_plugin(self, name):
+        """启用插件: 从禁用列表移除并持久化; 已加载则直接切换状态"""
+        changed = name in self._disabled_plugins
+        self._disabled_plugins.discard(name)
+        if changed:
+            self._save_disabled_plugins()
         if name in self._plugins:
             self._plugins[name].enabled = True
             self._rebuild_handler_list()
             return True
-        return False
+        return changed
 
     def disable_plugin(self, name):
+        """禁用插件: 加入禁用列表并持久化; 已加载则切换状态并重建索引"""
+        changed = name not in self._disabled_plugins
+        self._disabled_plugins.add(name)
+        if changed:
+            self._save_disabled_plugins()
         if name in self._plugins:
             self._plugins[name].enabled = False
             self._rebuild_handler_list()
             return True
-        return False
+        return changed
+
+    def is_plugin_disabled(self, name):
+        """检查插件是否在持久化禁用列表中"""
+        return name in self._disabled_plugins
+
+    def get_disabled_plugins(self):
+        """获取所有被持久化禁用的插件名列表"""
+        return sorted(self._disabled_plugins)
 
     def get_plugin_list(self):
         return [
             {
                 'name': p.name,
                 'enabled': p.enabled,
+                'disabled_persist': p.name in self._disabled_plugins,
                 'handlers': [h['name'] for h in p.handlers],
                 'handler_count': len(p.handlers),
                 'load_time': round(p.load_time, 3),
@@ -127,6 +150,53 @@ class PluginManager(_LoaderMixin, _WatcherMixin, _DispatchMixin, _BlacklistMixin
                 desc = p.module.__doc__.strip().split('\n')[0]
             result[p.name] = {'commands': cmds, 'description': desc, 'meta': p.meta}
         return result
+
+    # ==================== 禁用插件持久化 ====================
+
+    def _load_disabled_plugins(self):
+        path = os.path.join(self._base_dir, 'data', 'plugins_disabled.json')
+        if not os.path.isfile(path):
+            return
+        try:
+            with open(path, encoding='utf-8') as f:
+                data = json.load(f)
+                if isinstance(data, list):
+                    self._disabled_plugins = set(data)
+        except Exception as e:
+            log.warning(f'加载禁用插件列表失败: {e}')
+
+    def _save_disabled_plugins(self):
+        path = os.path.join(self._base_dir, 'data', 'plugins_disabled.json')
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        try:
+            with open(path, 'w', encoding='utf-8') as f:
+                json.dump(sorted(self._disabled_plugins), f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            log.warning(f'保存禁用插件列表失败: {e}')
+
+    def _migrate_ban_files(self):
+        """迁移旧版 .py.ban 文件: 自动纳入禁用列表并还原文件名"""
+        plugins_dir = self._dir
+        if not os.path.isdir(plugins_dir):
+            return
+        migrated = False
+        for root, _, files in os.walk(plugins_dir):
+            for f in files:
+                if not f.endswith('.py.ban'):
+                    continue
+                ban_path = os.path.join(root, f)
+                original = ban_path[:-4]  # 去掉 .ban
+                try:
+                    os.rename(ban_path, original)
+                    rel = os.path.relpath(root, plugins_dir)
+                    plugin_name = rel.split(os.sep)[0] if rel != '.' else os.path.basename(root)
+                    self._disabled_plugins.add(plugin_name)
+                    migrated = True
+                    log.info(f'迁移 .ban 文件: {ban_path} → 已禁用插件 [{plugin_name}]')
+                except OSError as e:
+                    log.warning(f'迁移 .ban 文件失败 [{ban_path}]: {e}')
+        if migrated:
+            self._save_disabled_plugins()
 
 
 def _resolve_allowed_bots(pb, plugin_name, file_name):

--- a/plugins/alone/示例插件.py
+++ b/plugins/alone/示例插件.py
@@ -1,10 +1,10 @@
 """示例功能: 媒体发送、ark卡片、markdown、撤回、主动消息、按钮等 (仅主人可用)"""
 
-import os
 import asyncio
+import os
+
 from core.plugin.decorators import handler, on_unload
 from core.plugin.web_pages import register_page, unregister_page
-
 
 # ==================== 媒体发送示例 ====================
 
@@ -190,7 +190,7 @@ async def force_wakeup_user(event, match):
 
 @handler(r'^全量签到$', name='签到', desc='无需@即可触发的签到指令', ignore_at_check=True)
 async def check_in(event, match):
-    await event.reply(f"✅ 签到成功！")
+    await event.reply("✅ 签到成功！")
 
 
 @handler(r'^主动测试$', name='全量主动测试', desc='无需@即可触发, 3秒后发送主动消息', ignore_at_check=True, owner_only=True)
@@ -312,8 +312,9 @@ def _unload_web_pages():
 @handler(r'^面板推送$', name='面板推送', desc='向 Web 面板推送一条自定义日志', owner_only=True)
 async def push_to_panel(event, match):
     try:
-        import web.ws as ws
         from datetime import datetime
+
+        import web.ws as ws
         entry = {
             'timestamp': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             'content': f'来自插件的推送测试 (用户: {event.user_id})',

--- a/web/tools/_plugin_mgr/files.py
+++ b/web/tools/_plugin_mgr/files.py
@@ -27,50 +27,58 @@ async def handle_command(event, match):
 
 
 async def handle_toggle_plugin(request: web.Request):
+    """启用/禁用插件 (持久化到 data/plugins_disabled.json)"""
     body = await request.json()
     plugin_path = body.get('path', '')
+    plugin_name = body.get('name', '')
     action = body.get('action', '')
-    if not plugin_path or action not in ('enable', 'disable'):
+
+    if action not in ('enable', 'disable'):
         return web.json_response({'success': False, 'message': '参数错误'}, status=400)
 
-    plugin_path = os.path.normpath(plugin_path)
+    # 优先使用 name (插件目录名), 否则从 path 推导
+    if not plugin_name and plugin_path:
+        plugin_path = os.path.normpath(plugin_path)
+        pdir = plugins_dir()
+        try:
+            rel = os.path.relpath(plugin_path, pdir)
+            plugin_name = rel.split(os.sep)[0]
+        except ValueError:
+            return web.json_response({'success': False, 'message': '无效路径'}, status=403)
+
+    if not plugin_name:
+        return web.json_response({'success': False, 'message': '缺少插件名或路径'}, status=400)
+
+    # 校验插件目录确实存在
     pdir = plugins_dir()
-    valid, abs_path = validate_path(plugin_path, pdir)
-    if not valid:
-        return web.json_response({'success': False, 'message': '无效路径'}, status=403)
+    plugin_dir = os.path.join(pdir, plugin_name)
+    if not os.path.isdir(plugin_dir):
+        return web.json_response({'success': False, 'message': f'插件目录不存在: {plugin_name}'}, status=404)
 
-    is_disable = action == 'disable'
-    expect_ext = '.py' if is_disable else '.py.ban'
-    if not abs_path.endswith(expect_ext):
-        return web.json_response({'success': False, 'message': f'只能操作 {expect_ext}'}, status=400)
-    new_abs = (abs_path + '.ban') if is_disable else abs_path[:-4]
-    if os.path.exists(new_abs):
-        return web.json_response({'success': False, 'message': '目标文件已存在'}, status=409)
-    os.rename(abs_path, new_abs)
-    await _try_reload_plugin(new_abs if not is_disable else abs_path, pdir)
-    label = '已禁用' if is_disable else '已启用'
-    return web.json_response(
-        {
-            'success': True,
-            'message': f'插件{label}',
-            'new_path': new_abs.replace('\\', '/'),
-        }
-    )
-
-
-async def _try_reload_plugin(file_path, pdir):
-    """根据文件路径推导插件名并触发运行时热重载"""
     pm = get_pm()
     if not pm:
-        return
+        return web.json_response({'success': False, 'message': '框架未启动或插件管理器未初始化'}, status=503)
+
     try:
-        rel = os.path.relpath(file_path, pdir)
-        plugin_name = rel.split(os.sep)[0]
-        if plugin_name and plugin_name in pm.plugins:
-            await pm.reload(plugin_name)
-            log.info(f'插件文件变更触发热重载: {plugin_name}')
+        if action == 'enable':
+            pm.enable_plugin(plugin_name)
+            if plugin_name not in pm.plugins:
+                # 插件在启动时被跳过, 现在加载
+                await pm.load(plugin_name)
+                pm._rebuild_handler_list()
+            label = '已启用'
+        else:
+            pm.disable_plugin(plugin_name)
+            label = '已禁用'
+
+        return web.json_response({
+            'success': True,
+            'message': f'插件 {plugin_name} {label}',
+            'plugin_name': plugin_name,
+        })
     except Exception as e:
-        log.warning(f'自动热重载失败: {e}')
+        log.error(f'插件 {action} [{plugin_name}] 失败: {e}')
+        return web.json_response({'success': False, 'message': f'操作异常: {e}'}, status=500)
 
 
 # ==================== 热重载 ====================

--- a/web/tools/_plugin_mgr/scan.py
+++ b/web/tools/_plugin_mgr/scan.py
@@ -8,7 +8,6 @@ from aiohttp import web
 from web.tools._plugin_mgr.shared import (
     ENTRY_CANDIDATES,
     find_entry,
-    find_entry_or_ban,
     get_pm,
     log,
     plugins_dir,
@@ -44,29 +43,23 @@ def _get_plugin_bots_map():
 
 
 def _scan_py_files(dir_path, prefix=''):
-    """扫描 .py / .py.ban 文件"""
+    """扫描 .py 文件 (只扫描 .py, 不再使用 .py.ban 禁用机制)"""
     files = []
     for fname in sorted(os.listdir(dir_path)):
         if fname.startswith('_'):
             continue
-        if fname.endswith('.py'):
-            enabled = True
-        elif fname.endswith('.py.ban'):
-            enabled = False
-        else:
+        if not fname.endswith('.py'):
             continue
         fpath = os.path.join(dir_path, fname)
         if not os.path.isfile(fpath):
             continue
         display = f'{prefix}{fname}' if prefix else fname
-        if not enabled and display.endswith('.ban'):
-            display = display[:-4]
         stat = os.stat(fpath)
         files.append(
             {
                 'name': display,
                 'path': fpath.replace('\\', '/'),
-                'enabled': enabled,
+                'enabled': True,
                 'size': stat.st_size,
                 'last_modified': datetime.fromtimestamp(stat.st_mtime).strftime('%Y-%m-%d %H:%M:%S'),
             }
@@ -83,28 +76,34 @@ def _scan_plugins():
     if not os.path.isdir(pdir):
         return result
     plugin_info_map = _get_plugin_info()
+    pm = get_pm()
+    disabled_set = pm.get_disabled_plugins() if pm else set()
 
     for dir_name in os.listdir(pdir):
         plugin_dir = os.path.join(pdir, dir_name)
         if not os.path.isdir(plugin_dir) or dir_name.startswith(('_', '.')):
             continue
         is_system = dir_name == 'system'
-        entry_path, enabled = find_entry_or_ban(plugin_dir)
+
+        # 持久化禁用状态优先
+        persist_disabled = dir_name in disabled_set
+        entry_path = find_entry(plugin_dir)
         if not entry_path:
             py_files = [f for f in os.listdir(plugin_dir) if f.endswith('.py') and not f.startswith('_')]
             if not py_files:
                 continue
             entry_path = os.path.join(plugin_dir, py_files[0])
-            enabled = True
 
         pinfo = plugin_info_map.get(dir_name, {})
         mtime = datetime.fromtimestamp(os.path.getmtime(entry_path)).strftime('%Y-%m-%d %H:%M:%S')
         is_large = find_entry(plugin_dir) is not None
+        loaded = dir_name in (pm.plugins if pm else {})
+        enabled = loaded and not persist_disabled
 
         result.append(
             {
                 'name': dir_name,
-                'status': 'loaded' if enabled else 'disabled',
+                'status': 'disabled' if persist_disabled else ('loaded' if loaded else 'unloaded'),
                 'path': entry_path.replace('\\', '/'),
                 'directory': dir_name,
                 'is_system': is_system,
@@ -116,26 +115,34 @@ def _scan_plugins():
                 'meta': pinfo.get('meta', {}),
             }
         )
-    result.sort(key=lambda x: (0 if x['status'] == 'loaded' else 1))
+    result.sort(key=lambda x: (0 if x['status'] == 'loaded' else 1 if x['status'] == 'unloaded' else 2))
     return result
 
 
 def _scan_plugin_dirs():
-    """按目录分组扫描所有 .py / .py.ban 文件"""
+    """按目录分组扫描所有 .py 文件 (禁用状态来自持久化)"""
     pdir = plugins_dir()
     dirs = []
     if not os.path.isdir(pdir):
         return dirs
     plugin_info_map = _get_plugin_info()
     bots_map = _get_plugin_bots_map()
+    pm = get_pm()
+    disabled_set = pm.get_disabled_plugins() if pm else set()
 
     for dir_name in sorted(os.listdir(pdir)):
         dir_path = os.path.join(pdir, dir_name)
         if not os.path.isdir(dir_path) or dir_name.startswith(('.', '__')):
             continue
         is_system = dir_name == 'system'
+        persist_disabled = dir_name in disabled_set
         pinfo = plugin_info_map.get(dir_name, {})
         files = _scan_py_files(dir_path)
+
+        # 标记文件级别的 enabled (持久化禁用则全部标记为 disabled)
+        if persist_disabled:
+            for f in files:
+                f['enabled'] = False
 
         for f in files:
             fname = f['name']
@@ -147,18 +154,21 @@ def _scan_plugin_dirs():
         if has_entry:
             app_dir = os.path.join(dir_path, 'app')
             if os.path.isdir(app_dir):
-                files.extend(_scan_py_files(app_dir, prefix='app/'))
+                sub_files = _scan_py_files(app_dir, prefix='app/')
+                if persist_disabled:
+                    for f in sub_files:
+                        f['enabled'] = False
+                files.extend(sub_files)
 
         if not files:
             continue
-        entry_enabled = any(f['name'] in ENTRY_CANDIDATES and f['enabled'] for f in files)
-        is_enabled = entry_enabled if has_entry else any(f['enabled'] for f in files)
 
+        loaded = dir_name in (pm.plugins if pm else {})
         dirs.append(
             {
                 'directory': dir_name,
                 'is_system': is_system,
-                'enabled': is_enabled,
+                'enabled': loaded and not persist_disabled,
                 'is_large': has_entry,
                 'files': files,
                 'allowed_bots': bots_map.get(dir_name, []),

--- a/web/tools/_plugin_mgr/shared.py
+++ b/web/tools/_plugin_mgr/shared.py
@@ -79,18 +79,6 @@ def find_entry(plugin_dir):
     return None
 
 
-def find_entry_or_ban(plugin_dir):
-    """查找入口文件或其 .ban 版本"""
-    for name in ENTRY_CANDIDATES:
-        path = os.path.join(plugin_dir, name)
-        if os.path.isfile(path):
-            return path, True
-        ban = path + '.ban'
-        if os.path.isfile(ban):
-            return ban, False
-    return None, None
-
-
 # ==================== 配置文件格式检测 ====================
 
 CONFIG_EXTS = frozenset(


### PR DESCRIPTION
核心变更 — data/plugins_disabled.json 替代 .py.ban 文件:
- PluginManager: 新增 _disabled_plugins set + _load_disabled_plugins()/_save_disabled_plugins()
- PluginManager: _migrate_ban_files() 自动迁移旧 .py.ban → JSON 禁用列表
- PluginManager: enable_plugin()/disable_plugin() 操作禁用集合并自动持久化
- PluginManager: is_plugin_disabled()/get_disabled_plugins() 新查询 API
- PluginManager: get_plugin_list() 新增 disabled_persist 字段

加载流程改进 (core/plugin/_loader.py):
- _load_all(): 启动时跳过 self._disabled_plugins 中的插件, 记录 skipped 计数
- load()/load_large(): 异常从 raise → log+return 优雅降级
  - 插件目录不存在 / 无 .py 文件 / 大型插件入口不存在 → error 日志而非崩溃

Web 面板适配 (web/tools/_plugin_mgr/):
- files.py handle_toggle_plugin(): 重写 — 不再操作 .py.ban 重命名, 改为调用 enable_plugin()/disable_plugin() + 必要时 load() 被跳过的插件
- scan.py: _scan_py_files() 不再扫描 .py.ban; _scan_plugins()/_scan_plugin_dirs() 改用 get_disabled_plugins() 获取状态; 排序 loaded→unloaded→disabled
- shared.py: 移除 find_entry_or_ban() 废弃函数

示例插件迁移:
- plugins/alone/示例插件.py.ban (353 lines) → 删除
- plugins/alone/示例插件.py (353 lines) → 恢复为 .py, 由 JSON 追踪禁用状态

.migrate_ban_files() 迁移策略:
- 遍历 plugins/ 目录查找 .py.ban 文件
- os.rename(.py.ban → .py) 恢复原文件
- 将插件名加入 _disabled_plugins 集合并持久化