### PR TITLE
feat(interaction): 支持插件自定义 op12 ACK code (#2)

### DIFF
--- a/core/bot/event.py
+++ b/core/bot/event.py
@@ -80,13 +80,10 @@ class EventHandlerMixin:
 
         et = event.event_type
 
-        if et == INTERACTION_CREATE:
-            interaction_id = event.message_id or event.event_id
-            if interaction_id:
-                try:
-                    await bot.sender.ack_interaction(event, interaction_id=interaction_id)
-                except Exception as e:
-                    log.warning(f'[{appid}] 交互ACK失败: {e}')
+        # 交互事件 (INTERACTION_CREATE) 的 op12 ACK 不再由框架在分发前自动发送,
+        # 改由传输层 (webhook / websocket) 在插件分发后, 用插件经
+        # event.set_callback_code() 设置的状态码发送; 插件未设置则用默认 code。
+        # 参见 core/server/webhook.py 与 core/network/websocket.py。
 
         # 去重 (setdefault 避免二次查找)
         if cfg.get_bot_setting(appid, 'dedup.enabled', False):

--- a/core/message/event.py
+++ b/core/message/event.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """事件数据容器 + 类型常量"""
 
+import asyncio
 import json
 from functools import partial
 
@@ -16,6 +17,10 @@ from core.message.parsers import (
     parse_interaction,
     parse_message_generic,
 )
+
+# 交互回调 (op12 ACK) 默认状态码与默认等待插件超时 (秒)
+_DEFAULT_CALLBACK_CODE = 0
+_DEFAULT_ACK_TIMEOUT = 2.0
 
 # ==================== 事件类型常量 ====================
 
@@ -182,6 +187,10 @@ class Event:
         '_sender',
         '_reply_log_cb',
         '_reply_plugin_name',
+        'callback_code',
+        '_ack_future',
+        '_ack_timer',
+        '_ack_timeout',
     )
 
     def __init__(self):
@@ -229,6 +238,11 @@ class Event:
         self._sender = None
         self._reply_log_cb = None
         self._reply_plugin_name = ''
+        # 交互回调 (op12) 状态码: 插件可通过 set_callback_code() 自定义
+        self.callback_code = None
+        self._ack_future = None
+        self._ack_timer = None
+        self._ack_timeout = _DEFAULT_ACK_TIMEOUT
 
     # ==================== 构造 ====================
 
@@ -358,6 +372,62 @@ class Event:
     @property
     def needs_event_id(self):
         return self.event_type in _EVENT_ID_TYPES
+
+    # ==================== 交互回调 (op12 ACK) ====================
+    # 插件可在处理 INTERACTION_CREATE 时调用 event.set_callback_code(n) 自定义
+    # 返回给客户端的状态码 (随 op12 ACK 一起发送, 不额外发 REST 请求)。
+    # 未设置则框架在分发结束 / 超时后用默认 code 兜底。
+
+    def start_ack_countdown(self):
+        """交互事件开始处理: 创建 ACK future 并启动默认超时定时器。
+
+        由传输层 (webhook / websocket) 在分发插件前调用。
+        """
+        loop = asyncio.get_running_loop()
+        if self._ack_future is None:
+            self._ack_future = loop.create_future()
+        self._reschedule_ack_timer()
+
+    def _reschedule_ack_timer(self):
+        loop = asyncio.get_running_loop()
+        if self._ack_timer is not None:
+            self._ack_timer.cancel()
+        self._ack_timer = loop.call_later(self._ack_timeout, self._fire_default_ack)
+
+    def set_ack_timeout(self, seconds):
+        """插件自定义等待时长 (秒), 用于需要持续处理后再返回 code 的插件。"""
+        self._ack_timeout = float(seconds)
+        if self._ack_timer is not None and self._ack_future is not None and not self._ack_future.done():
+            self._reschedule_ack_timer()
+
+    def set_callback_code(self, code):
+        """插件设置交互回调状态码 (随 op12 ACK 立即返回, 插件可继续运行)。"""
+        self.callback_code = int(code)
+        self._resolve_ack(self.callback_code)
+
+    def _resolve_ack(self, code):
+        if self._ack_timer is not None:
+            self._ack_timer.cancel()
+            self._ack_timer = None
+        if self._ack_future is not None and not self._ack_future.done():
+            self._ack_future.set_result(code)
+
+    def _fire_default_ack(self):
+        """超时兜底: 插件迟迟未设置 code, 用默认 code 返回。"""
+        self._ack_timer = None
+        if self._ack_future is not None and not self._ack_future.done():
+            self._ack_future.set_result(_DEFAULT_CALLBACK_CODE)
+
+    def finish_dispatch(self):
+        """插件分发结束: 若插件未自定义 code, 立即用默认 code 返回 (不等满超时)。"""
+        if self._ack_future is not None and not self._ack_future.done():
+            self._resolve_ack(_DEFAULT_CALLBACK_CODE)
+
+    async def wait_ack_code(self):
+        """等待交互 code: 插件设置 / 分发结束 / 超时 三者任一触发后返回。"""
+        if self._ack_future is None:
+            return _DEFAULT_CALLBACK_CODE
+        return await self._ack_future
 
     # ==================== 发送代理 ====================
     # event.reply(...) → sender.reply(event, ...)

--- a/core/network/websocket.py
+++ b/core/network/websocket.py
@@ -139,8 +139,6 @@ class WSClient:
     async def _on_dispatch(self, payload):
         """事件分发 → 构造 Event 并回调"""
         event_type = payload.get('t', '')
-        if event_type == 'INTERACTION_CREATE':
-            await self._send_event_ack(payload)
         if event_type == 'READY':
             self._session_id = payload.get('d', {}).get('session_id')
             log.info(f'[{self._appid}] WebSocket 已就绪 (session={self._session_id})')
@@ -151,9 +149,25 @@ class WSClient:
         try:
             event = Event.from_websocket(self._appid, payload)
             log.debug(f'[{self._appid}] WS事件: {event}')
-            asyncio.create_task(self._dispatch_with_backpressure(event))
+            if event_type == 'INTERACTION_CREATE':
+                # 先分发插件 (插件可 set_callback_code), 再用其 code 发 op12 ACK;
+                # ACK 在独立任务里等待, 不阻塞 WS 读取循环。
+                event.start_ack_countdown()
+                task = asyncio.create_task(self._dispatch_with_backpressure(event))
+                task.add_done_callback(lambda t, ev=event: ev.finish_dispatch())
+                asyncio.create_task(self._ack_interaction_when_ready(event, payload))
+            else:
+                asyncio.create_task(self._dispatch_with_backpressure(event))
         except Exception as e:
             log.error(f'[{self._appid}] 事件处理异常: {e}')
+
+    async def _ack_interaction_when_ready(self, event, payload):
+        """等待插件设置 code (或分发结束/超时) 后发送 op12 ACK。"""
+        try:
+            code = await event.wait_ack_code()
+        except Exception:
+            code = 0
+        await self._send_event_ack(payload, code)
 
     async def _dispatch_with_backpressure(self, event):
         """背压包装: Semaphore 控制并发, 满载时新事件等待空闲槽位"""

--- a/core/server/webhook.py
+++ b/core/server/webhook.py
@@ -11,6 +11,17 @@ from core.message.event import Event
 log = logging.getLogger('ElainaBot.webhook')
 
 
+def _finish_interaction(event, task):
+    """交互事件分发结束回调: 取出异常 + 若插件未设置 code 则用默认 code 返回。"""
+    try:
+        exc = task.exception()
+    except Exception:
+        exc = None
+    if exc is not None:
+        log.warning(f'[Webhook] 交互事件分发异常: {exc!r}')
+    event.finish_dispatch()
+
+
 class WebhookHandler:
     """处理 QQ Bot webhook 回调: 签名验证 → 事件构造 → 分发"""
 
@@ -44,15 +55,26 @@ class WebhookHandler:
             return web.Response(text=sig_resp, content_type='application/json') if success else web.json_response({'error': 'invalid validation'}, status=400)
 
         # 事件构造与分发
+        import asyncio
+
+        is_interaction = body.get('t') == 'INTERACTION_CREATE'
         try:
             event = Event.from_webhook(headers, body)
-            import asyncio
-
-            asyncio.create_task(self._on_event(event))
+            if is_interaction:
+                # 启动 ACK 倒计时, 分发结束后用插件设置的 code 兜底/返回
+                event.start_ack_countdown()
+                task = asyncio.create_task(self._on_event(event))
+                task.add_done_callback(lambda t, ev=event: _finish_interaction(ev, t))
+            else:
+                asyncio.create_task(self._on_event(event))
         except Exception as e:
             self._on_error({'appid': appid, 'source': 'Webhook', 'error': e})
+            if is_interaction:
+                return web.json_response({'op': 12, 'code': 0})
+            return web.json_response({})
 
-        # 交互事件返回 ACK
-        if body.get('t') == 'INTERACTION_CREATE':
-            return web.json_response({'op': 12, 'code': 0})
+        # 交互事件: 等待插件设置 code (或分发结束/超时), 随 op12 ACK 返回
+        if is_interaction:
+            code = await event.wait_ack_code()
+            return web.json_response({'op': 12, 'code': code})
         return web.json_response({})


### PR DESCRIPTION
交互事件 (INTERACTION_CREATE) 的 op12 ACK 不再由框架在分发前自动发送, 改由传输层在插件分发后发送, 让插件通过 event.set_callback_code(n) 自定义 返回给客户端的状态码; 未设置则用默认 0 兜底。

- Event 新增 set_callback_code / set_ack_timeout 及内部 ACK future + 定时器
- 默认等待 2s; 插件未设置 code 且分发结束则立即返回 (不等满超时); 插件可 set_ack_timeout 自定义等待时长 (持续化返回场景)
- webhook: HTTP 响应体携带 {op:12, code}
- websocket: 独立任务等待 code 后发 op12 帧, 不阻塞读取循环
- 移除 core/bot/event.py 分发前自动 REST ack_interaction