### PR TITLE
feat(core): 完善消息发送与群消息历史查询

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ config/local.*
 # --- 配置文件: 示例文件受版本控制, 实际配置本地化 ---
 config/*.yaml
 !config/*.example.yaml
+/plugins

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Project Working Preferences
+
+- Do not include `.yaml` files in Git commits or pull requests. Check staged paths and the final PR diff before publishing. To remove an already submitted YAML change, restore the base-branch content instead of deleting an existing configuration file.
+- Before creating or updating a pull request, validate the encoding of every added or modified text file in the PR diff. Decode files strictly as UTF-8 (without replacement characters), scan for Unicode replacement characters and common mojibake sequences, and manually inspect changed user-visible Chinese text in the rendered diff.
+- Submit PR titles and descriptions as explicit UTF-8 bytes. After creating or updating a PR, read the title and description back from the remote API or rendered page and verify the expected Chinese text exactly; a successful API response is not sufficient.
+- Never treat successful tests or normal-looking terminal output as sufficient encoding validation. Read text with an explicit UTF-8 encoding or validate the raw bytes; PowerShell's default `Get-Content` rendering may use a different code page.
+- When synchronizing text files to `Elainabot_v2-modules`, compare the source and destination after strict UTF-8 decoding and CRLF/LF normalization. Do not rely only on raw file hashes, because line-ending differences can hide whether the actual text is equivalent.
+- Do not create or update the pull request until the UTF-8 validation, mojibake scan, and normalized source/destination comparison all pass.

--- a/core/message/_http.py
+++ b/core/message/_http.py
@@ -76,7 +76,7 @@ def _describe_exception(e, method, endpoint):
     if detail:
         msg += f': {detail}'
     msg += f') {method} {endpoint}'
-    return {'message': msg, 'code': -1}
+    return {'message': msg, 'code': 500}
 
 
 class _HttpMixin:

--- a/core/message/event.py
+++ b/core/message/event.py
@@ -214,6 +214,7 @@ class Event:
         'is_channel',
         'is_interaction',
         'is_lifecycle',
+        'is_full',
         'interaction_data',
         'scene',
         'sharer_id',
@@ -272,6 +273,7 @@ class Event:
         self.is_channel = False
         self.is_interaction = False
         self.is_lifecycle = False
+        self.is_full = False
         self.interaction_data = None
         self.scene = None
         self.sharer_id = None

--- a/core/message/keyboard.py
+++ b/core/message/keyboard.py
@@ -20,10 +20,16 @@ def build_keyboard(button_rows, appid=None, *, font_size=None, style=None):
         buttons = []
         if isinstance(row, dict):
             row = row.get('buttons') or row.get('btns') or []
+        if not isinstance(row, list | tuple):
+            continue
         for btn in row:
-            r_data = btn.get('render_data') or {}
+            if not isinstance(btn, dict):
+                continue
+            raw_render_data = btn.get('render_data')
+            r_data = raw_render_data if isinstance(raw_render_data, dict) else {}
             r_data.setdefault('style', btn.get('style', 1))
-            action = btn.get('action') or {}
+            raw_action = btn.get('action')
+            action = raw_action if isinstance(raw_action, dict) else {}
             action.setdefault('type', btn.get('type', 2))
             action.setdefault('data', btn.get('data', ''))
             button_id = btn.get('id')
@@ -39,62 +45,62 @@ def build_keyboard(button_rows, appid=None, *, font_size=None, style=None):
             if 'group_id' in btn:
                 b['group_id'] = btn['group_id']
             # 自定义字段覆盖
-            if show := btn.get('show'):
-                r_data.setdefault('visited_label', show)
-            if text := btn.get('text'):
+            if 'show' in btn:
+                r_data.setdefault('visited_label', btn.get('show'))
+            if 'text' in btn:
+                text = btn.get('text') or ''
                 r_data['label'] = text
                 r_data.setdefault('visited_label', text)
             # link 优先 (覆盖 type/data)
             if 'link' in btn:
-                b['action']['type'] = 0
-                b['action']['data'] = btn['link']
+                action['type'] = 0
+                action['data'] = btn['link']
 
             # enter 行为: button_enter_to_send 配置开启时, type=2+enter -> type=1
             if btn.get('enter'):
-                act = b['action']
-                if button_enter_to_send and act['type'] == 2:
-                    act['type'] = 1
+                if button_enter_to_send and action['type'] == 2:
+                    action['type'] = 1
                 else:
-                    act['enter'] = True
+                    action['enter'] = True
 
             if btn.get('reply'):
-                b['action']['reply'] = True
+                action['reply'] = True
 
             # 权限: 显式 permission > role > list > admin > 默认所有人
             if 'permission' in btn:
-                b['action']['permission'] = btn['permission']
+                action['permission'] = btn['permission']
             elif 'role' in btn:
-                b['action']['permission'] = {'type': 3, 'specify_role_ids': btn['role']}
+                action['permission'] = {'type': 3, 'specify_role_ids': btn['role']}
             elif 'list' in btn:
-                b['action']['permission'] = {'type': 0, 'specify_user_ids': btn['list']}
-            elif btn.get('admin'):
-                b['action']['permission'] = {'type': 1}
-            else:
-                b['action']['permission'] = {'type': 2}
+                action['permission'] = {'type': 0, 'specify_user_ids': btn['list']}
+            elif 'admin' in btn:
+                action['permission'] = {'type': 2 if btn.get('admin') else 1}
+            if 'permission' not in action:
+                action['permission'] = {'type': 1}
 
             # 点击次数限制
             if 'limit' in btn:
-                b['action']['click_limit'] = btn['limit']
+                action['click_limit'] = btn['limit']
 
             # 不支持时提示
             if 'tips' in btn:
-                b['action']['unsupport_tips'] = btn['tips']
+                action['unsupport_tips'] = btn['tips']
 
             # 二次确认弹窗
             if modal := btn.get('modal'):
-                b['action']['modal'] = {'content': modal} if isinstance(modal, str) else modal
+                action['modal'] = {'content': modal} if isinstance(modal, str) else modal
 
             # 订阅按钮: subscribe -> type=4 + subscribe_data
             if (sub := btn.get('subscribe')) is not None:
-                b['action']['type'] = 4
-                b['action']['subscribe_data'] = _build_subscribe_data(sub)
+                action['type'] = 4
+                action['subscribe_data'] = _build_subscribe_data(sub)
 
             # 平台原生 action 字段直接写在 btn 里时原样透传
             for key in ('subscribe_data', 'click_limit', 'unsupport_tips', 'anchor'):
                 if key in btn:
-                    b['action'][key] = btn[key]
+                    action[key] = btn[key]
             if 'subscribe_data' in btn and 'type' not in btn:
-                b['action']['type'] = 4
+                action['type'] = 4
 
             buttons.append(b)
         rows.append({'buttons': buttons})
@@ -183,6 +189,13 @@ def convert_simple_ark_data(template_id, simple_data):
     if template_id == 23:
         return _build_ark23(simple_data)
     return simple_data
+
+
+def build_ark(template_id, kv_data):
+    """构建 Ark 载荷，并对内置模板应用简写转换。"""
+    if isinstance(kv_data, tuple | list) and template_id in (23, 24, 37):
+        kv_data = convert_simple_ark_data(template_id, kv_data)
+    return {'template_id': template_id, 'kv': kv_data}
 
 
 def _build_ark23(simple_data):

--- a/core/message/keyboard.py
+++ b/core/message/keyboard.py
@@ -74,9 +74,9 @@ def build_keyboard(button_rows, appid=None, *, font_size=None, style=None):
             elif 'list' in btn:
                 action['permission'] = {'type': 0, 'specify_user_ids': btn['list']}
             elif 'admin' in btn:
-                action['permission'] = {'type': 2 if btn.get('admin') else 1}
+                action['permission'] = {'type': 1 if btn.get('admin') else 2}
             if 'permission' not in action:
-                action['permission'] = {'type': 1}
+                action['permission'] = {'type': 2}
 
             # 点击次数限制
             if 'limit' in btn:

--- a/core/message/media.py
+++ b/core/message/media.py
@@ -34,17 +34,20 @@ async def upload_media_bytes(sender, file_bytes, file_type, endpoint, *, file_na
     # 大文件走分片 (带重试)
     if isinstance(file_bytes, bytes) and len(file_bytes) > CHUNK_THRESHOLD:
         for retry in range(max_retry):
+            retry_msg = '' if retry == 0 else f'(retry{retry}/{max_retry})'
             try:
                 result = await _chunked_upload_from_bytes(sender, file_bytes, file_type, endpoint, file_name=file_name)
                 if result:
                     return result
-                sender.error = PromptTpl.UploadMediaFail.d({'retry_msg': '分片上传返回空结果 (无 file_info)'})
+                sender.error = PromptTpl.UploadMediaFail.d({
+                    'retry_msg': retry_msg,
+                    'e': '分片上传返回空结果 (无 file_info)',
+                })
             except Exception as e:
-                retry_msg = '' if retry == 0 else f'(retry{retry}/{max_retry})'
                 sender.error = PromptTpl.UploadMediaFail.d({'retry_msg': retry_msg, 'e': e})
                 _log_upload_issue(file_type, f'[{sender._appid}] 分片上传第{retry + 1}次失败: {e}')
-                if retry < max_retry - 1:
-                    await asyncio.sleep(2 * (retry + 1))
+            if retry < max_retry - 1:
+                await asyncio.sleep(2 * (retry + 1))
         err = sender.error if hasattr(sender, 'error') else '未知错误'
         _log_upload_issue(file_type, f'[{sender._appid}] 分片上传{max_retry}次均失败, 最后错误: {err}')
         return None

--- a/core/message/media.py
+++ b/core/message/media.py
@@ -9,6 +9,7 @@ import os
 import tempfile
 
 from core.base.logger import FRAMEWORK, get_logger
+from core.prompt_exception import PromptTpl
 
 log = get_logger(FRAMEWORK, '媒体上传')
 
@@ -24,7 +25,7 @@ def _log_upload_issue(file_type, message):
 # ==================== 上传 ====================
 
 
-async def upload_media_bytes(sender, file_bytes, file_type, endpoint, *, file_name=None, event=None):
+async def upload_media_bytes(sender, file_bytes, file_type, endpoint, *, file_name=None, max_retry: int = 3, event=None):
     """上传媒体 bytes, 返回 file_info (>5MB 自动分片)"""
     if not file_bytes:
         return None
@@ -32,19 +33,20 @@ async def upload_media_bytes(sender, file_bytes, file_type, endpoint, *, file_na
         return None
     # 大文件走分片 (带重试)
     if isinstance(file_bytes, bytes) and len(file_bytes) > CHUNK_THRESHOLD:
-        last_err = None
-        for retry in range(3):
+        for retry in range(max_retry):
             try:
                 result = await _chunked_upload_from_bytes(sender, file_bytes, file_type, endpoint, file_name=file_name)
                 if result:
                     return result
-                last_err = '分片上传返回空结果 (无 file_info)'
+                sender.error = PromptTpl.UploadMediaFail.d({'retry_msg': '分片上传返回空结果 (无 file_info)'})
             except Exception as e:
-                last_err = e
+                retry_msg = '' if retry == 0 else f'(retry{retry}/{max_retry})'
+                sender.error = PromptTpl.UploadMediaFail.d({'retry_msg': retry_msg, 'e': e})
                 _log_upload_issue(file_type, f'[{sender._appid}] 分片上传第{retry + 1}次失败: {e}')
-                if retry < 2:
+                if retry < max_retry - 1:
                     await asyncio.sleep(2 * (retry + 1))
-        _log_upload_issue(file_type, f'[{sender._appid}] 分片上传3次均失败, 最后错误: {last_err}')
+        err = sender.error if hasattr(sender, 'error') else '未知错误'
+        _log_upload_issue(file_type, f'[{sender._appid}] 分片上传{max_retry}次均失败, 最后错误: {err}')
         return None
 
     req_data = {
@@ -158,6 +160,7 @@ async def chunked_upload(sender, file_path, file_type, endpoint, *, file_name=No
         **hashes,
     }
     prep = None
+    # 上传前进行检查，有概率失败，故进行重试（不消耗带宽）
     for prep_retry in range(3):
         success, prep = await sender.post_json(f'{scope}/upload_prepare', prep_data)
         if success:
@@ -179,6 +182,7 @@ async def chunked_upload(sender, file_path, file_type, endpoint, *, file_name=No
         chunk_size = min(block_size, file_size - offset)
         chunk = await asyncio.get_running_loop().run_in_executor(None, _read_chunk, file_path, offset, chunk_size)
 
+        # 上传前进行检查，有概率失败，故进行重试（不消耗带宽）
         for retry in range(3):
             try:
                 resp = await sender._client.put(
@@ -209,6 +213,7 @@ async def chunked_upload(sender, file_path, file_type, endpoint, *, file_name=No
     success, result = await sender.post_json(f'{scope}/files', {'upload_id': upload_id})
     if success:
         return result.get('file_info')
+    sender.error = result
     return None
 
 

--- a/core/message/parsers/group.py
+++ b/core/message/parsers/group.py
@@ -34,6 +34,7 @@ class GroupMessageParser(MessageParser):
     def parse(self, event, d: dict):
         super().parse(event, d)
         is_full = event.event_type == 'GROUP_MESSAGE_CREATE'
+        event.is_full = is_full
         self.handle_mentions(event, d, is_full)
         if is_full and event.appid:
             only_self_at = event.is_at_self and not event.is_at_other_bot and not event.is_at_other_user and not event.is_at_all

--- a/core/message/sender.py
+++ b/core/message/sender.py
@@ -26,9 +26,9 @@ from core.message._media_send import (
 )
 from core.message._sender_log import _SenderLogMixin
 from core.message.keyboard import (
+    build_ark,
     build_keyboard,
     build_prompt_keyboard,
-    convert_simple_ark_data,
 )
 from core.message.media import get_image_size as _get_image_size
 from core.message.media import upload_media_bytes, upload_media_via_url
@@ -84,6 +84,8 @@ def _parse_stream_chunk(item):
 
 class MessageSender(_HttpMixin, _MediaSendMixin, _SenderLogMixin):
     """消息发送器 (每个机器人实例一个)"""
+
+    GROUP_MEMBER_MUTE_BATCH_SIZE = 20
 
     __slots__ = (
         '_token_mgr',
@@ -387,13 +389,11 @@ class MessageSender(_HttpMixin, _MediaSendMixin, _SenderLogMixin):
         return await self._send_media(event, file_data, 4, content, file_name=file_name, **kw)
 
     async def reply_ark(self, event, template_id, kv_data, content='', *, auto_delete_time=None):
-        if isinstance(kv_data, tuple | list) and template_id in (23, 24, 37):
-            kv_data = convert_simple_ark_data(template_id, kv_data)
         payload = {
             'msg_type': MSG_TYPE_ARK,
             'msg_seq': _msg_seq(),
             'content': content or '',
-            'ark': {'template_id': template_id, 'kv': kv_data},
+            'ark': build_ark(template_id, kv_data),
         }
         _set_msg_or_event_id(payload, event)
         endpoint = event.reply_endpoint
@@ -626,7 +626,7 @@ class MessageSender(_HttpMixin, _MediaSendMixin, _SenderLogMixin):
             if user_openids is not None
             else ('group_openids', group_openids)
         )
-        if not isinstance(values, (list, tuple)):
+        if not isinstance(values, list | tuple):
             return None, cls._api_error(f'{key} 必须为列表')
         if len(values) > 20:
             return None, cls._api_error(f'{key} 单次最多提供 20 个')
@@ -773,15 +773,20 @@ class MessageSender(_HttpMixin, _MediaSendMixin, _SenderLogMixin):
             json={'op': op, **targets},
         )
 
-    async def get_group_member(self, group_id, member_id=None, *, member_openid=None):
-        """查询单个群成员详情, 返回 dict, 失败返回 None"""
+    async def get_group_member(self, group_id, member_id=None, *, member_openid=None, return_error=False):
+        """查询单个群成员详情；return_error=True 时同时返回平台错误。"""
         member_id = member_id or member_openid
         if not group_id or not member_id:
-            return None
-        success, data = await self.get_json(f'/v2/groups/{group_id}/members/{member_id}')
-        if success and isinstance(data, dict):
-            return data
-        return None
+            error = {'message': '缺少 group_id 或 member_id', 'code': -1}
+            return (None, error) if return_error else None
+        success, data = await self._request_group(
+            group_id,
+            f'members/{member_id}',
+            handle_error=not return_error,
+        )
+        if success:
+            return (data, None) if return_error else data
+        return (None, data) if return_error else None
 
     get_group_member_info = get_group_member
 
@@ -1163,10 +1168,10 @@ class MessageSender(_HttpMixin, _MediaSendMixin, _SenderLogMixin):
 
     async def set_group_member_mute(self, group_id, members):
         """批量增加、更新或解除成员禁言，单次最多处理 20 人。"""
-        if not isinstance(members, (list, tuple)):
+        if not isinstance(members, list | tuple):
             return False, {'message': 'members 必须为列表', 'code': -1}
-        if len(members) > 20:
-            return False, {'message': '单次最多设置 20 个成员', 'code': -1}
+        if len(members) > self.GROUP_MEMBER_MUTE_BATCH_SIZE:
+            return False, {'message': f'单次最多设置 {self.GROUP_MEMBER_MUTE_BATCH_SIZE} 个成员', 'code': -1}
         if any(not isinstance(item, dict) for item in members):
             return False, {'message': 'members 中的每一项都必须为字典', 'code': -1}
         return await self._request_group(
@@ -1225,6 +1230,9 @@ class MessageSender(_HttpMixin, _MediaSendMixin, _SenderLogMixin):
             payload['media'] = media
             if content:
                 payload['content'] = content
+        elif msg_type == MSG_TYPE_ARK:
+            payload['msg_type'] = MSG_TYPE_ARK
+            payload['content'] = content or ''
         elif msg_type == MSG_TYPE_MARKDOWN or (use_md and msg_type != MSG_TYPE_TEXT):
             payload['msg_type'] = MSG_TYPE_MARKDOWN
             md_content = str(content) if content is not None else ''

--- a/core/prompt_exception/__init__.py
+++ b/core/prompt_exception/__init__.py
@@ -1,0 +1,4 @@
+from .prompt_exception import PromptException
+from .templates import PromptTpl
+
+__all__ = ['PromptException', 'PromptTpl']

--- a/core/prompt_exception/prompt_exception.py
+++ b/core/prompt_exception/prompt_exception.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+
+class PromptException:
+    db: ClassVar[dict[int, PromptException]] = {}
+
+    def __init__(self, msg: str, code: int = 500, data: dict = None, as_tpl: bool = False) -> None:
+        if hasattr(msg, 'value'):
+            self.msg = msg.value
+        else:
+            self.msg = str(msg)
+        self.data = data or {}
+        self.code = code
+        if as_tpl is True:
+            self.db[code] = self
+
+    def __str__(self) -> str:
+        return self.msg
+
+    @property
+    def value(self):
+        return self.msg
+
+    def __repr__(self) -> str:
+        return f'PExp[{self.code}]{self.msg}'
+
+    def format_msg(self, args: dict[str, str]):
+        val = str(self.msg)
+        if args is None:
+            return val
+        val = val.format_map(args)
+        return val
+
+    def to_dict(self, args: dict[str, str] = None):
+        r = {
+            'code': self.code,
+            'msg': self.format_msg(args),
+        }
+        if self.data:
+            r['data'] = self.data
+        return r
+
+    def d(self, args: dict[str, str] = None, data: dict = None):
+        "创建实例"
+        tpl = self.db.get(self.code) or self
+        val = tpl.format_msg(args)
+        return PromptException(val, tpl.code, data or self.data)

--- a/core/prompt_exception/prompt_exception.py
+++ b/core/prompt_exception/prompt_exception.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import ClassVar
 
 
 class PromptException:
     db: ClassVar[dict[int, PromptException]] = {}
 
-    def __init__(self, msg: str, code: int = 500, data: dict = None, as_tpl: bool = False) -> None:
-        if hasattr(msg, 'value'):
-            self.msg = msg.value
-        else:
-            self.msg = str(msg)
+    def __init__(self, msg: object, code: int = 500, data: dict | None = None, as_tpl: bool = False) -> None:
+        self.msg = str(getattr(msg, 'value', msg))
         self.data = data or {}
         self.code = code
         if as_tpl is True:
@@ -20,21 +18,19 @@ class PromptException:
         return self.msg
 
     @property
-    def value(self):
+    def value(self) -> str:
         return self.msg
 
     def __repr__(self) -> str:
         return f'PExp[{self.code}]{self.msg}'
 
-    def format_msg(self, args: dict[str, str]):
-        val = str(self.msg)
+    def format_msg(self, args: Mapping[str, object] | None) -> str:
         if args is None:
-            return val
-        val = val.format_map(args)
-        return val
+            return self.msg
+        return self.msg.format_map(args)
 
-    def to_dict(self, args: dict[str, str] = None):
-        r = {
+    def to_dict(self, args: Mapping[str, object] | None = None) -> dict[str, object]:
+        r: dict[str, object] = {
             'code': self.code,
             'msg': self.format_msg(args),
         }
@@ -42,7 +38,7 @@ class PromptException:
             r['data'] = self.data
         return r
 
-    def d(self, args: dict[str, str] = None, data: dict = None):
+    def d(self, args: Mapping[str, object] | None = None, data: dict | None = None) -> PromptException:
         "创建实例"
         tpl = self.db.get(self.code) or self
         val = tpl.format_msg(args)

--- a/core/prompt_exception/templates.py
+++ b/core/prompt_exception/templates.py
@@ -1,0 +1,5 @@
+from .prompt_exception import PromptException
+
+
+class PromptTpl:
+    UploadMediaFail = PromptException('upload_media_bytes{retry_msg}.fail:{e}', 5001001)

--- a/core/storage/log.py
+++ b/core/storage/log.py
@@ -98,6 +98,67 @@ class LogService(_BaseLogService, ShareMixin, WakeupMixin, SubscribeMixin):
         """同步查询 data.db (users/groups/members 表)"""
         return self.query('data', sql, params)
 
+    async def get_group_message_history(
+        self,
+        group_id: str,
+        limit: int,
+        before_message_seq: int = 0,
+    ) -> list[dict]:
+        """按新到旧查询群消息，游标包含锚点消息。"""
+        await self._flush_type('message')
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            self._get_group_message_history_sync,
+            str(group_id),
+            int(limit),
+            int(before_message_seq),
+        )
+
+    def _get_group_message_history_sync(
+        self,
+        group_id: str,
+        limit: int,
+        before_message_seq: int,
+    ) -> list[dict]:
+        if limit <= 0 or not os.path.isdir(self._base_dir):
+            return []
+
+        cursor_day = before_message_seq >> 32 if before_message_seq > 0 else 0
+        cursor_row = before_message_seq & 0xFFFFFFFF
+        dates = []
+        for name in os.listdir(self._base_dir):
+            try:
+                ordinal = datetime.strptime(name, '%Y-%m-%d').toordinal()
+            except ValueError:
+                continue
+            if os.path.isfile(self._resolve_db_path('message', name)):
+                dates.append((ordinal, name))
+
+        result: list[dict] = []
+        for ordinal, name in sorted(dates, reverse=True):
+            if cursor_day and ordinal > cursor_day:
+                continue
+
+            params: list = [group_id]
+            row_filter = ''
+            if cursor_day and ordinal == cursor_day:
+                row_filter = ' AND id <= ?'
+                params.append(cursor_row)
+            params.append(limit - len(result))
+            rows = self.query(
+                'message',
+                f'SELECT * FROM log WHERE group_id = ?{row_filter} ORDER BY id DESC LIMIT ?',
+                tuple(params),
+                date=name,
+            )
+            for row in rows:
+                row['message_seq'] = (ordinal << 32) | int(row['id'])
+            result.extend(rows)
+            if len(result) >= limit:
+                break
+        return result
+
     def _extract_row(self, log_type, data):
         """dict → INSERT 参数元组"""
         ts = data.get('timestamp', now_str())

--- a/web/auth.py
+++ b/web/auth.py
@@ -66,6 +66,7 @@ def hash_password(plain: str) -> str:
 
 def verify_password(plain: str, stored: str) -> bool:
     """恒定时间比较, 兼容明文旧密码"""
+    stored = str(stored)
     if stored.startswith(_PWD_HASH_PREFIX):
         try:
             rest = stored[len(_PWD_HASH_PREFIX) :]
@@ -80,7 +81,7 @@ def verify_password(plain: str, stored: str) -> bool:
 
 
 def is_hashed(stored: str) -> bool:
-    return stored.startswith(_PWD_HASH_PREFIX)
+    return str(stored).startswith(_PWD_HASH_PREFIX)
 
 
 # ==================== JSON 文件读写 ====================


### PR DESCRIPTION
新增跨日期群消息历史查询，补充消息构建和群成员错误返回能力，并完善媒体上传错误处理与密码兼容逻辑。PR 涉及 13 个文件。

## 主要变动

- 群消息历史按时间倒序查询，支持跨日期、包含游标锚点的分页。
- 补充完整群消息标记，统一 Ark 载荷构建，增强键盘输入容错。默认按钮保持所有人可用，admin 按钮保持管理员权限，并保留显式权限配置。
- 媒体上传支持可配置重试次数和错误模板；空结果与异常均按重试间隔处理，完整保留原始失败原因，成功或取消时及时结束重试。HTTP 异常错误码改为 500。
- 群成员查询支持可选错误返回，兼容 main 的 member_openid 参数，保留其 20 人禁言上限、成员分页和黑名单能力。
- 异常模板包使用显式导入和 __all__，仅公开 PromptException、PromptTpl。补全可空参数和返回值类型，格式化参数支持异常及数字，确保消息始终为字符串。
- 兼容非字符串的已存储密码，补充插件忽略规则和 PR 编码要求。

## 提交范围

PR 及本分支提交均不包含 .yaml、modules、plugins 和相关 OneBot 测试。原有 YAML 配置文件保留 main 内容，AGENTS.md 已记录禁止提交 .yaml 的规则。测试资产继续使用 ci-assets，补充的验证用例在仓库外执行。保留 main 后续修复，未同步模块仓库。

## 验证

- 机器人的两条通配符导入意见已修复。最新 CI 暴露的 6 个类型错误，以及此前 5 个键盘权限测试失败均已修复。
- ci-assets 的键盘、事件、群成员和媒体测试，群消息历史跨日期游标测试，以及错误模板和上传失败重试的补充回归测试：共 91 项通过。
- 与 CI 相同的后端类型检查 mypy core web main.py：133 个源文件全部通过。PR 中变更的 Python 文件 Ruff 检查通过。
- 13 个新增或修改文件通过严格 UTF-8 解码、替换字符与常见乱码扫描；已核对中文差异，以及索引与工作文件经 CRLF/LF 规范化后的文本一致性。git diff --check 和 Python 语法解析通过。
- 未执行前端构建或浏览器测试。最新提交 f201db4 的远程 CI 和 Python 代码扫描均已通过。
